### PR TITLE
adicionando o botao não sei o CEP

### DIFF
--- a/app/Livewire/Assisted/CreateMultiStep/StepThree.php
+++ b/app/Livewire/Assisted/CreateMultiStep/StepThree.php
@@ -23,24 +23,43 @@ class StepThree extends Component
   public ?string $lastFetchedCep = null;
   public int $cepRequestSeq = 0;
   public int $activeCepRequestSeq = 0;
-
-  #[Validate([
-    'data.zipcode' => ['required', 'regex:/^\d{5}-\d{3}$/'],
-    'data.address' => 'required|string|max:150',
-    'data.number' => 'required|numeric',
-    'data.neighborhood' => 'required|string|max:100',
-    'data.city' => 'required|string|max:100',
-    'data.state' => 'required|string|max:2',
-  ], message: [
-    'data.*.required' => 'Campo obrigatório.',
-    'data.*.numeric' => 'O campo deve conter apenas números.',
-    'data.*.max' => 'Tamanho máximo do campo excedido.',
-    'data.zipcode.regex' => 'CEP inválido.',
-  ])]
+  public $dontKnowZipcode = false;
+  protected function rules()
+  {
+    return [
+      'data.zipcode'      => $this->dontKnowZipcode ? 'nullable' : 'required|min:8|max:9',
+      'data.address'      => 'required|string|max:150',
+      'data.number'       => 'required|numeric',
+      'data.neighborhood' => 'required|string|max:100',
+      'data.city'         => 'required|string|max:100',
+      'data.state'        => 'required|string|max:2',
+    ];
+  }
+  protected function messages()
+  {
+    return [
+      'data.zipcode.required' => 'O CEP é obrigatório.',
+      'data.*.required'       => 'Campo obrigatório.',
+      'data.*.numeric'        => 'O campo deve conter apenas números.',
+      'data.*.max'            => 'Tamanho máximo do campo excedido.',
+    ];
+  }
 
   public function mount($data)
   {
     $this->data = $data;
+
+    $this->dontKnowZipcode = $data['dontKnowZipcode'] ?? false;
+  }
+
+  public function updatedDontKnowZipcode($value)
+  {
+    $this->data['dontKnowZipcode'] = $value;
+    if ($value) {
+      $this->data['zipcode'] = '';
+      $this->cepError = null;
+      $this->resetErrorBag('data.zipcode');
+    }
   }
 
   private function normalizeCep(string $value): string

--- a/resources/views/livewire/assisted/create-multi-step/step-three.blade.php
+++ b/resources/views/livewire/assisted/create-multi-step/step-three.blade.php
@@ -9,7 +9,7 @@
         <div class="col-12 col-md-4 col-xl mb-3">
           <label for="cepAddressAssisted" class="form-label">CEP</label>
           <div class="position-relative">
-            <input type="text" class="form-control @error('data.zipcode') is-invalid @enderror @if ($cepError) is-invalid @endif" id="cepAddressAssisted" x-mask="99999-999" wire:model.live="data.zipcode" wire:blur="fetchAddressByCepFromZipcode" placeholder="99999-999"/>
+            <input type="text" class="form-control @error('data.zipcode') is-invalid @enderror @if ($cepError) is-invalid @endif" id="cepAddressAssisted" x-mask="99999-999" wire:model.live="data.zipcode" wire:blur="fetchAddressByCepFromZipcode" placeholder="99999-999" @if($dontKnowZipcode) disabled @endif/>
             <div
               class="position-absolute top-50 end-0 translate-middle-y me-3"
               wire:loading.flex
@@ -18,6 +18,17 @@
             >
               <div class="spinner-border spinner-border-sm text-primary" role="status" aria-hidden="true"></div>
             </div>
+          </div>
+          <div class="form-check mt-2">
+            <input
+              class="form-check-input"
+              type="checkbox"
+              id="unknownZipcode"
+              wire:model.live="dontKnowZipcode"
+            >
+            <label class="form-check-label" for="unknownZipcode">
+              Não sei o CEP
+            </label>
           </div>
           @error('data.zipcode') <span class="d-block invalid-feedback">{{ $message }}</span> @enderror
           @if ($cepError)


### PR DESCRIPTION
This pull request introduces a new "Não sei o CEP" ("I don't know the zip code") checkbox option to the assisted creation form, allowing users to proceed without entering a zip code. The changes include UI updates, new validation logic, and state handling for when the user does not know the zip code.

**User Experience Improvements:**

* Added a checkbox in the UI (`step-three.blade.php`) allowing users to indicate they don't know the zip code, which disables the zip code input field when checked. [[1]](diffhunk://#diff-4751e2fac72fc11303e816a9df0d85ee83dd382368e605fe4d2c359376e72967R22-R32) [[2]](diffhunk://#diff-4751e2fac72fc11303e816a9df0d85ee83dd382368e605fe4d2c359376e72967L12-R12)

**Validation and State Handling:**

* Updated the validation rules in `StepThree.php` to make the zip code field optional if the "don't know zip code" option is selected, and provided custom validation messages.
* Introduced state management for the new `dontKnowZipcode` property in `StepThree.php`, including logic to reset the zip code field and validation errors when the checkbox is toggled.